### PR TITLE
fix: 处理 issue #2/#3/#4（zse-ck 签名、Release 流水线、仅APP阅读文档）

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,17 +1,15 @@
 # ============================================================================
-# GitHub Actions - 自动构建 Windows exe 并发布 Release
+# GitHub Actions - 手动构建 Windows exe（Wine 交叉编译）
 # ============================================================================
 # 触发条件：
-#   1. 推送 v* 标签 → 构建并发布到 GitHub Release
-#   2. 手动触发 → 仅构建，上传 artifact
+#   - 仅手动触发（workflow_dispatch），构建并上传 artifact
+#   - v* 标签发布已由 .github/workflows/release.yml 统一负责
+#     （原生 windows-latest 构建 Windows CLI），本文件保留用于 Wine 交叉编译调试
 # ============================================================================
 
-name: Build Windows EXE
+name: Build Windows EXE (Wine)
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,174 @@
+# ============================================================================
+# GitHub Actions - CLI 发布流水线（issue #3）
+# ============================================================================
+# 触发条件：
+#   1. 推送 v* 标签（如 v3.1.0）→ 构建两个平台的 CLI 产物并发布到 GitHub Release
+#   2. 手动触发（workflow_dispatch）→ 仅构建并上传 artifact，便于在合并前验证
+#
+# 产物矩阵（本次只发 CLI 产物，Tauri GUI 走独立流水线 build-tauri.yml）：
+#   - Linux x86_64  : zhihu-downloader-<version>-linux-x64.tar.gz   （ubuntu-24.04 + Python 3.12）
+#   - Windows x64    : zhihu-downloader-<version>-windows-x64.zip   （windows-2022 + Python 3.12）
+#
+# 设计要点：
+#   - 每个平台用 native runner 直接跑 PyInstaller（Windows 不交叉编译，避免 Wine 依赖地狱）
+#   - 依赖来源单一：`pip install .` 按 pyproject.toml 安装全部运行时依赖 + pyinstaller
+#   - 复用仓库现有 pyinstaller.spec（onefile，入口 src/zhihu_downloader/__main__.py）
+#   - GUI 前端资源不在本流水线构建，spec 检测不到 web/dist 时会降级为「纯 CLI」并打印警告
+#   - 权限最小化：顶层只给 contents: read，仅 release 任务升级为 contents: write
+# ============================================================================
+
+name: Release CLI (Linux + Windows)
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  PYTHON_VERSION: "3.12"
+
+# 权限最小化：默认只读，创建 Release 的任务单独升级写入权限
+permissions:
+  contents: read
+
+jobs:
+  # ----------------------------------------------------------------------
+  # 1. 构建 Linux x86_64 可执行文件
+  # ----------------------------------------------------------------------
+  build-linux:
+    name: Linux x64 CLI
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 安装 Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+
+      - name: 安装依赖（pyproject.toml 全部运行时依赖 + PyInstaller）
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "pyinstaller>=6.0.0"
+          python -m pip install .
+
+      - name: PyInstaller 打包
+        run: |
+          pyinstaller pyinstaller.spec --clean -y --log-level WARN
+          ls -lh dist/
+
+      - name: 验证 CLI 可运行
+        run: |
+          file dist/zhihu-downloader
+          dist/zhihu-downloader --help | head -20
+
+      - name: 打包分发产物（含版本号与平台）
+        shell: bash
+        run: |
+          # tag 触发用标签版本；手动触发用 dev-<短sha> 作为占位，避免分支名含斜杠等非法字符
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="dev-${GITHUB_SHA::8}"
+          fi
+          mkdir -p release
+          cp dist/zhihu-downloader release/zhihu-downloader
+          cp README.md release/README.txt
+          tar -czf "zhihu-downloader-${VERSION}-linux-x64.tar.gz" -C release .
+          ls -lh "zhihu-downloader-${VERSION}-linux-x64.tar.gz"
+          echo "ARTIFACT=zhihu-downloader-${VERSION}-linux-x64.tar.gz" >> "$GITHUB_ENV"
+
+      - name: 上传 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zhihu-downloader-linux-x64
+          path: ${{ env.ARTIFACT }}
+          retention-days: 30
+
+  # ----------------------------------------------------------------------
+  # 2. 构建 Windows x64 可执行文件
+  # ----------------------------------------------------------------------
+  build-windows:
+    name: Windows x64 CLI
+    runs-on: windows-2022
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 安装 Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+
+      - name: 安装依赖（pyproject.toml 全部运行时依赖 + PyInstaller）
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "pyinstaller>=6.0.0"
+          python -m pip install .
+
+      - name: PyInstaller 打包
+        shell: pwsh
+        run: |
+          pyinstaller pyinstaller.spec --clean -y --log-level WARN
+          Get-ChildItem dist | Select-Object Name, Length
+
+      - name: 验证 CLI 可运行
+        shell: pwsh
+        run: |
+          dist\zhihu-downloader.exe --help | Select-Object -First 20
+
+      - name: 打包分发产物（含版本号与平台）
+        shell: pwsh
+        run: |
+          # tag 触发用标签版本；手动触发用 dev-<短sha> 作为占位
+          if ("${{ github.ref_type }}" -eq "tag") {
+            $version = "${{ github.ref_name }}" -replace '^v', ''
+          } else {
+            $version = "dev-$("${{ github.sha }}".Substring(0, 8))"
+          }
+          New-Item -ItemType Directory -Force -Path release | Out-Null
+          Copy-Item dist\zhihu-downloader.exe release\
+          Copy-Item web\src-tauri\icons\icon.ico release\ 2>$null
+          Copy-Item README.md release\README.txt
+          Compress-Archive -Path release\* -DestinationPath "zhihu-downloader-$version-windows-x64.zip"
+          Get-ChildItem "zhihu-downloader-$version-windows-x64.zip" | Select-Object Name, Length
+          "ARTIFACT=zhihu-downloader-$version-windows-x64.zip" >> $env:GITHUB_ENV
+
+      - name: 上传 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zhihu-downloader-windows-x64
+          path: ${{ env.ARTIFACT }}
+          retention-days: 30
+
+  # ----------------------------------------------------------------------
+  # 3. 创建 / 更新 GitHub Release（仅 tag 触发时）
+  # ----------------------------------------------------------------------
+  release:
+    name: 发布 GitHub Release
+    needs: [build-linux, build-windows]
+    runs-on: ubuntu-24.04
+    if: startsWith(github.ref, 'refs/tags/v')
+    # 仅此任务需要写权限（创建 Release + 上传资产），
+    # 使用 softprops/action-gh-release@v2 内部自动取用 GITHUB_TOKEN。
+    permissions:
+      contents: write
+    steps:
+      - name: 下载全部产物
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+          merge-multiple: true
+
+      - name: 创建 / 更新 GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release-artifacts/*
+          generate_release_notes: true
+          fail_on_unmatched_files: false

--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,6 @@ Thumbs.db
 output/
 *.epub
 *.txt
-*.md
 *.mobi
 
 # uv

--- a/README.md
+++ b/README.md
@@ -42,6 +42,35 @@
 | **Windows 简易版** | Win 10/11 x64 | `zhihu-downloader-windows-x64.zip`（单文件 EXE） |
 | **Web 静态** | 任意静态服务器 | `zhihu-web-static.zip` |
 
+## 支持范围与限制
+
+### 支持的 URL
+
+| URL 类型 | 示例 | 说明 |
+|----------|------|------|
+| 公开回答 | `https://www.zhihu.com/question/<id>/answer/<id>` | 默认最佳支持，直接解析正文 |
+| 专栏文章 | `https://zhuanlan.zhihu.com/p/<id>` | 公开专栏，直接解析正文 |
+| 盐选专栏 | `https://www.zhihu.com/market/paid_column/<col_id>` | 下载整本书目录，需 Cookie 含有效 `z_c0` |
+| 盐选单章节 | `https://www.zhihu.com/market/paid_column/<col_id>/section/<sec_id>` | 仅下载该章节，需有效 `z_c0` |
+| story.zhihu.com 非仅APP形式 | `https://story.zhihu.com/manuscript/paid_column/...` | 若同一内容在网页端有对应 market URL 且可读，则可用 |
+
+### 暂不支持
+
+- **「仅 APP 内阅读」盐选小说**：`story.zhihu.com/manuscript/paid_column/...` 中只能在知乎 APP 内打开的内容。
+  原因：接口请求需要 APP 级 `mst` / `xsec` 签名与设备信息（如 `x-zse-96`），
+  网页端没有合法入口，当前版本无法直接下载正文（传入此类 URL 会给出明确提示而非静默失败）。
+
+### 替代方案
+
+1. **优先找同一内容的 web market URL**：将 `story.zhihu.com/manuscript/paid_column/<col_id>`
+   替换为 `https://www.zhihu.com/market/paid_column/<col_id>`（章节同理补 `/section/<sec_id>`），
+   网页端能正常打开并看到正文即可下载。
+2. **使用 APP 内人工方式**：利用知乎 APP 的缓存 / 截图 / 手动复制保存正文，再配合本工具整理导出。
+3. **网页可读但有 zse-ck 反爬**：更新 Cookie（确保含 `z_c0` 与可用的 `zse_ck`），
+   并参考仓库中新增的 `x-zse-96` 签名模块重新生成请求头。
+
+> 完整的「URL 类型 × 支持状态 × 说明 × 替代方案」矩阵见 [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md)。
+
 ## 技术栈
 
 ### 后端 (Python 3.10+)

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -1,0 +1,97 @@
+# 支持范围与限制（Support Matrix）
+
+本文档列出 zhihu-salt-novel-downloader 对各类型知乎 URL 的支持状态、说明与替代方案，
+用于解决 issue #2 中「仅 APP 内阅读」内容的文档与体验缺口。
+
+URL 分类逻辑与运行时提示实现于 `src/zhihu_downloader/plugins/sources/zhihu_salt.py`，
+运行时会在终端 / SSE 进度流中给出友好提示（见
+`src/zhihu_downloader/services/download_service.py` 的 `_emit_url_hint`）。
+
+## 状态图例
+
+| 状态 | 含义 |
+|------|------|
+| ✅ 支持 | 网页端可直接解析并下载正文 |
+| ⚠️ 有条件支持 | 需要有效 Cookie 或对应网页入口，否则可能为空或触发反爬 |
+| ❌ 暂不支持 | 需要移动端签名（`mst`/`xsec`），网页端无合法入口 |
+
+## URL 类型 × 支持状态
+
+| URL 类型 | 示例 | 支持状态 | 说明 | 替代方案 |
+|----------|------|----------|------|----------|
+| 公开回答 | `https://www.zhihu.com/question/<id>/answer/<id>` | ✅ 支持 | 默认最佳支持，无需付费 Cookie，可直接解析 RichText 正文 | — |
+| 专栏文章 | `https://zhuanlan.zhihu.com/p/<id>` | ✅ 支持 | 公开专栏文章，直接解析正文 | — |
+| 盐选专栏（市场付费） | `https://www.zhihu.com/market/paid_column/<col_id>` | ⚠️ 有条件支持 | 下载整本书目录，需 Cookie 含有效 `z_c0` | 更新 Cookie（见下文） |
+| 盐选单章节 | `https://www.zhihu.com/market/paid_column/<col_id>/section/<sec_id>` | ⚠️ 有条件支持 | 仅下载该章节，不获取全书目录；需有效 `z_c0` | 改用专栏整书 URL |
+| 移动端付费专栏（非仅 APP 形式） | `https://story.zhihu.com/manuscript/paid_column/<col_id>` | ⚠️ 如可用 | 若同一内容在网页端有对应 market URL 且可读，则可用 | 优先替换为 `www.zhihu.com/market/paid_column/...` |
+| 移动端单章节（非仅 APP 形式） | `https://story.zhihu.com/manuscript/paid_column/<col_id>/<sec_id>` | ⚠️ 如可用 | 路径不带 `/section/` 关键词；网页端可读则可用 | 优先替换为 market section URL |
+| 移动端付费专栏（仅 APP 内阅读） | `https://story.zhihu.com/manuscript/paid_column/<col_id>` | ❌ 暂不支持 | 需 APP 级 `mst`/`xsec` 签名与设备信息，网页端无合法入口 | 见下方「替代方案」 |
+| 移动端单章节（仅 APP 内阅读） | `https://story.zhihu.com/manuscript/paid_column/<col_id>/<sec_id>` | ❌ 暂不支持 | 同上 | 见下方「替代方案」 |
+| 非知乎系 URL | `https://example.com/...` | ❌ 不支持 | 不属于知乎系域名，无法解析 | 检查 URL 是否正确 |
+
+> **注意**：`story.zhihu.com/manuscript/paid_column/...` 链接本身并不直接等同于「仅 APP 内阅读」。
+> 同一内容可能存在两种形态：
+> 1. **非仅 APP 形式** —— 在网页端有对应的 market URL 且正文可读，本工具可用；
+> 2. **仅 APP 内阅读形式** —— 只能在知乎 APP 内打开，依赖移动端 API 签名，本工具暂不支持。
+>
+> 当前版本对 `story.zhihu.com` 链接统一判定为「仅 APP 内阅读」并给出提示，
+> 因此建议优先改用网页版 market URL 以获得最佳体验。
+
+## 什么是「仅 APP 内阅读」
+
+「仅 APP 内阅读」是指内容没有公开的网页端正文入口，只能通过知乎移动端 App 打开。
+其接口请求需要 `mst` / `xsec` 等签名参数以及设备信息（如 `x-zse-96`、`x-zse-93` 等）。
+这些签名由 App 内计算生成，网页端没有合法入口，因此当前版本无法直接下载正文。
+
+## 替代方案
+
+### ① 优先找同一内容的 web market URL
+
+「仅 APP 内阅读」内容通常也有对应的网页版盐选入口：
+
+- 在知乎网页版搜索书名 / 章节标题；
+- 将 `story.zhihu.com/manuscript/paid_column/<col_id>` 替换为
+  `https://www.zhihu.com/market/paid_column/<col_id>`；
+- 章节同理：`.../manuscript/paid_column/<col_id>/<sec_id>` →
+  `https://www.zhihu.com/market/paid_column/<col_id>/section/<sec_id>`；
+- 若网页端能正常打开并看到正文，即可用本工具下载。
+
+### ② 使用 APP 内的人工方式
+
+若确实没有网页端入口，可退而求其次：
+
+- 使用知乎 APP 的「缓存 / 离线」功能保存到本地；
+- 截图保存章节；
+- 手动复制正文到本地文档；
+- 再配合本工具的导出 / 书架功能整理。
+
+### ③ 网页可读但有 zse-ck 反爬
+
+若网页端正文可读，但请求被知乎 `zse-ck`（配合 `x-zse-96`）反爬拦截：
+
+1. 在浏览器中重新登录知乎，导出最新 Cookie（确保包含 `z_c0`，以及可用的 `zse_ck`）；
+2. 使用 `--auto-cookie` 自动从浏览器读取，或手动更新 Cookie 文件；
+3. 参考仓库中新增的 `x-zse-96` 签名模块（见 issue #4 对应实现）重新生成请求头。
+
+## 快速判断流程
+
+```text
+拿到 URL
+  ├─ 是知乎系域名？
+  │    └─ 否 → ❌ 不支持，检查 URL 是否正确
+  └─ 是
+       ├─ www.zhihu.com/question/.../answer/...  → ✅ 直接下载
+       ├─ zhuanlan.zhihu.com/p/...               → ✅ 直接下载
+       ├─ www.zhihu.com/market/paid_column/...   → ⚠️ 需有效 z_c0，可直接下载
+       ├─ story.zhihu.com/manuscript/...         → 先找网页 market URL
+       │     ├─ 找到且网页可读      → ✅ 用 market URL 下载
+       │     └─ 找不到（仅 APP 内阅读）→ ❌ 用替代方案 ①/②
+       └─ 其他 → 参考上方支持矩阵
+```
+
+## 相关文件
+
+- URL 分类与提示逻辑：`src/zhihu_downloader/plugins/sources/zhihu_salt.py`
+- 提示文案：`src/zhihu_downloader/services/download_service.py`（`_emit_url_hint`）
+- 章节 ID 解析：`src/zhihu_downloader/parsers/article_parser.py`
+- 单元测试：`tests/test_sources.py`

--- a/src/zhihu_downloader/core/downloader.py
+++ b/src/zhihu_downloader/core/downloader.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import random
 import time
+import urllib.parse
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 
@@ -14,6 +15,7 @@ import aiohttp
 from .cache import ResponseCache
 from .circuit_breaker import CircuitBreaker, CircuitBreakerOpenError
 from .rate_limiter import RateLimiter
+from .zhihu_signature import XZSE_93_VERSION, generate_zhihu_sign
 
 if TYPE_CHECKING:
     from aiohttp import ClientResponse
@@ -289,7 +291,7 @@ class AsyncDownloader:
 
         async with self._semaphore:
             session = await self._get_session()
-            request_headers = self._build_headers(headers)
+            request_headers = self._build_headers(headers, url)
             request_proxy = proxy or self._get_random_proxy()
 
             try:
@@ -404,13 +406,42 @@ class AsyncDownloader:
                         new_concurrent,
                     )
 
-    def _build_headers(self, custom_headers: dict[str, str] | None = None) -> dict[str, str]:
-        """构建请求头，随机选择UA"""
+    def _build_headers(
+        self,
+        custom_headers: dict[str, str] | None = None,
+        url: str | None = None,
+    ) -> dict[str, str]:
+        """构建请求头，随机选择UA，并为知乎系请求追加签名头（可被自定义头覆盖）"""
         headers = self.DEFAULT_HEADERS.copy()
         headers["User-Agent"] = random.choice(self._ua_pool)
+        if url:
+            headers.update(self._build_signature_headers(url))
         if custom_headers:
             headers.update(custom_headers)
         return headers
+
+    def _build_signature_headers(self, url: str) -> dict[str, str]:
+        """为知乎系请求计算 x-zse-96 / x-zst-81 / x-zse-93 签名请求头。
+
+        仅当请求 host 属于知乎系域名且 cookies 含 d_c0 时返回签名头；
+        否则返回空字典。
+        """
+        if not self._is_zhihu_url(url) or "d_c0" not in self._cookies:
+            return {}
+        signature = generate_zhihu_sign(url, self._cookies)
+        if not signature:
+            return {}
+        signature["x-zse-93"] = XZSE_93_VERSION
+        return signature
+
+    @staticmethod
+    def _is_zhihu_url(url: str) -> bool:
+        """判断 URL 是否属于知乎系域名（zhihu.com 及其子域）。"""
+        try:
+            host = (urllib.parse.urlparse(url).hostname or "").lower()
+        except ValueError:
+            return False
+        return host == "zhihu.com" or host.endswith(".zhihu.com")
 
     def _get_random_proxy(self) -> str | None:
         """从代理池随机选择代理"""

--- a/src/zhihu_downloader/core/zhihu_signature.py
+++ b/src/zhihu_downloader/core/zhihu_signature.py
@@ -1,0 +1,238 @@
+"""知乎 x-zse-96 / x-zst-81 签名模块。
+
+纯 Python 移植自 MediaCrawler 的 zhihu.js（SM4 风格分组密码），
+参考实现来自公开仓库 Smart75850/smart-agent 的 zhihu_sign.py。
+
+许可说明：
+- MediaCrawler (NanmiCoder/MediaCrawler) 采用 Apache License 2.0；
+- 本移植仅使用 Python 标准库（hashlib/random/re），不引入任何第三方加密依赖。
+
+算法要点：
+    x-zst-81 为固定常量；x-zse-96 = "2.0_" + base64-ish(
+        SM4 风格的 48 字节初始化数组变换，
+        输入为 md5(f"{version}+{url}+{d_c0}+{x_zst_81}") 的 hex
+    )，其中每个签名的随机前缀来自 random.randint(0, 127)。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+
+__all__ = ["XZSE_93_VERSION", "generate_zhihu_sign"]
+
+#: 请求头 x-zse-93 的版本号（与签名 md5 的 version 保持一致）
+XZSE_93_VERSION = "101_3_3.0"
+
+#: x-zse-96 最终编码表（64 字符）
+_INIT_STR = "6fpLRqJO8M/c3jnYxFkUVC4ZIG12SiH=5v0mXDazWBTsuw7QetbKdoPyAl+hN9rgE"
+
+#: SM4 风格密钥扩展常量（32 个 32 位有符号整数）
+_ZK = [
+    1170614578,
+    1024848638,
+    1413669199,
+    -343334464,
+    -766094290,
+    -1373058082,
+    -143119608,
+    -297228157,
+    1933479194,
+    -971186181,
+    -406453910,
+    460404854,
+    -547427574,
+    -1891326262,
+    -1679095901,
+    2119585428,
+    -2029270069,
+    2035090028,
+    -1521520070,
+    -5587175,
+    -77751101,
+    -2094365853,
+    -1243052806,
+    1579901135,
+    1321810770,
+    456816404,
+    -1391643889,
+    -229302305,
+    330002838,
+    -788960546,
+    363569021,
+    -1947871109,
+]
+
+#: SM4 风格 S 盒（256 字节）
+_ZB = [
+    20, 223, 245, 7, 248, 2, 194, 209, 87, 6, 227, 253, 240, 128, 222, 91,
+    237, 9, 125, 157, 230, 93, 252, 205, 90, 79, 144, 199, 159, 197, 186, 167,
+    39, 37, 156, 198, 38, 42, 43, 168, 217, 153, 15, 103, 80, 189, 71, 191,
+    97, 84, 247, 95, 36, 69, 14, 35, 12, 171, 28, 114, 178, 148, 86, 182,
+    32, 83, 158, 109, 22, 255, 94, 238, 151, 85, 77, 124, 254, 18, 4, 26,
+    123, 176, 232, 193, 131, 172, 143, 142, 150, 30, 10, 146, 162, 62, 224, 218,
+    196, 229, 1, 192, 213, 27, 110, 56, 231, 180, 138, 107, 242, 187, 54, 120,
+    19, 44, 117, 228, 215, 203, 53, 239, 251, 127, 81, 11, 133, 96, 204, 132,
+    41, 115, 73, 55, 249, 147, 102, 48, 122, 145, 106, 118, 74, 190, 29, 16,
+    174, 5, 177, 129, 63, 113, 99, 31, 161, 76, 246, 34, 211, 13, 60, 68,
+    207, 160, 65, 111, 82, 165, 67, 169, 225, 57, 112, 244, 155, 51, 236, 200,
+    233, 58, 61, 47, 100, 137, 185, 64, 17, 70, 234, 163, 219, 108, 170, 166,
+    59, 149, 52, 105, 24, 212, 78, 173, 45, 0, 116, 226, 119, 136, 206, 135,
+    175, 195, 25, 92, 121, 208, 126, 139, 3, 75, 141, 21, 130, 98, 241, 40,
+    154, 66, 184, 49, 181, 46, 243, 88, 101, 183, 8, 23, 72, 188, 104, 179,
+    210, 134, 250, 201, 164, 89, 216, 202, 220, 50, 221, 152, 140, 33, 235, 214,
+]
+
+#: x-zst-81 固定常量
+_TC = (
+    "3_2.0aR_sn77yn6O92wOB8hPZnQr0EMYxc4f18wNBUgpTQ6nxERFZfTY0-4Lm-h3_tufIwJS8gcxTgJS_AuPZNcXCTwxI78YxEM20s4PGDwN8gGcYAupMWufIoLVqr4gxrRPOI0cY7HL8qun9g93mFukyigcmebS_FwOYPRP0E4rZUrN9DDom3hnynAUMnAVPF_PhaueTFH9fQL39OCCqYTxfb0rfi9wfPhSM6vxGDJo_rBHpQGNmBBLqPJHK2_w8C9eTVMO9Z9NOrMtfhGH_DgpM-BNM1DOxScLG3gg1Hre1FCXKQcXKkrSL1r9GWDXMk8wqBLNmbRH96BtOFqVZ7UYG3gC8D9cMS7Y9UrHLVCLZPJO8_CL_6GNCOg_zhJS8PbXmGTcBpgxfkieOPhNfthtf2gC_qD3YOce8nCwG2uwBOqeMoML9NBC1xb9yk6SuJhHLK7SM6LVfCve_3vLKlqcL6TxL_UosDvHLxrHmWgxBQ8Xs"
+)
+
+
+def _to_unsigned(n: int) -> int:
+    """转为无符号 32 位整数。"""
+    return n & 0xFFFFFFFF
+
+
+def _i(val: int, arr: list, offset: int) -> None:
+    """将 32 位整数按大端序写入 arr[offset:offset+4]。"""
+    arr[offset] = 255 & (val >> 24)
+    arr[offset + 1] = 255 & (val >> 16)
+    arr[offset + 2] = 255 & (val >> 8)
+    arr[offset + 3] = 255 & val
+
+
+def _Q(val: int, shift: int) -> int:
+    """32 位循环左移。"""
+    return _to_unsigned((_to_unsigned(val) << shift) | (_to_unsigned(val) >> (32 - shift)))
+
+
+def _B(arr: list, offset: int) -> int:
+    """按大端序读取 4 字节为有符号 32 位整数。"""
+    v = (
+        (255 & arr[offset]) << 24
+        | (255 & arr[offset + 1]) << 16
+        | (255 & arr[offset + 2]) << 8
+        | 255 & arr[offset + 3]
+    )
+    return v if v < 0x80000000 else v - 0x100000000
+
+
+def _G(val: int) -> int:
+    """S 盒替换 + 线性变换（SM4 的 T 变换）。"""
+    t = [0] * 4
+    n = [0] * 4
+    _i(val, t, 0)
+    n[0] = _ZB[255 & t[0]]
+    n[1] = _ZB[255 & t[1]]
+    n[2] = _ZB[255 & t[2]]
+    n[3] = _ZB[255 & t[3]]
+    r = _B(n, 0)
+    return _to_unsigned(r ^ _Q(r, 2) ^ _Q(r, 10) ^ _Q(r, 18) ^ _Q(r, 24))
+
+
+def _array_0_16_offset(arr: list) -> list:
+    """SM4 32 轮密钥扩展，返回 16 字节。"""
+    t = [0] * 16
+    n = [0] * 36
+    n[0] = _B(arr, 0)
+    n[1] = _B(arr, 4)
+    n[2] = _B(arr, 8)
+    n[3] = _B(arr, 12)
+    for r in range(32):
+        o = _G(_to_unsigned(n[r + 1] ^ n[r + 2] ^ n[r + 3] ^ _ZK[r]))
+        n[r + 4] = _to_unsigned(n[r] ^ o)
+    _i(n[35], t, 0)
+    _i(n[34], t, 4)
+    _i(n[33], t, 8)
+    _i(n[32], t, 12)
+    return t
+
+
+def _array_16_48_offset(arr: list, prev: list) -> list:
+    """处理剩余数据块。"""
+    result = []
+    t = prev[:]
+    for i in range(0, len(arr), 16):
+        block = arr[i : i + 16]
+        a = [0] * 16
+        for c in range(16):
+            a[c] = block[c] ^ t[c]
+        t = _array_0_16_offset(a)
+        result.extend(t)
+    return result
+
+
+def _encode_0_16(arr: list) -> list:
+    """对前 16 字节做固定偏移异或与 42 异或后做密钥扩展。"""
+    array_offset = [48, 53, 57, 48, 53, 51, 102, 55, 100, 49, 53, 101, 48, 49, 100, 55]
+    result = []
+    for i in range(len(arr)):
+        a = arr[i] ^ array_offset[i]
+        b = a ^ 42
+        result.append(b)
+    return _array_0_16_offset(result)
+
+
+def _encode_3bytes(ar: list) -> list:
+    """将 3 字节编码为 4 个 6bit 索引（base64 风格）。"""
+    b_val = ar[1] << 8
+    c_val = ar[0] | b_val
+    d_val = ar[2] << 16
+    e_val = c_val | d_val
+    result = [e_val & 63]
+    x = 6
+    while len(result) < 4:
+        result.append((e_val >> x) & 63)
+        x += 6
+    return result
+
+
+def _get_init_array(md5_hex: str) -> list:
+    """由 md5 hex 构造 48 字节初始化数组。"""
+    init = [ord(c) for c in md5_hex]
+    init.insert(0, 0)
+    init.insert(0, random.randint(0, 127))
+    while len(init) < 48:
+        init.append(14)
+    a0 = _encode_0_16(init[:16])
+    a48 = _array_16_48_offset(init[16:48], a0)
+    return a0 + a48
+
+
+def _get_zse_96(md5_hex: str) -> str:
+    """由 md5 hex 计算 x-zse-96 签名。"""
+    init_arr = _get_init_array(md5_hex)
+    for i in range(47, -1, -4):
+        init_arr[i] ^= 58
+    init_arr.reverse()
+
+    result_chars = []
+    for j in range(3, len(init_arr) + 1, 3):
+        ar = init_arr[j - 3 : j]
+        result_chars.extend(_encode_3bytes(ar))
+
+    result = "".join(_INIT_STR[idx] for idx in result_chars)
+    return "2.0_" + result
+
+
+def generate_zhihu_sign(url: str, cookies: dict[str, str]) -> dict[str, str]:
+    """生成知乎 x-zst-81 与 x-zse-96 签名请求头。
+
+    Args:
+        url: 请求的完整 URL（含 query string）。
+        cookies: Cookie 字典，需包含 ``d_c0``。
+
+    Returns:
+        包含 ``x-zst-81`` 与 ``x-zse-96`` 的字典；当 cookies 缺少 ``d_c0``
+        时返回空字典。
+    """
+    dc0 = cookies.get("d_c0")
+    if not dc0:
+        return {}
+    join_str = "+".join([XZSE_93_VERSION, url or "", dc0, _TC])
+    md5_hex = hashlib.md5(join_str.encode("utf-8")).hexdigest()
+    return {
+        "x-zst-81": _TC,
+        "x-zse-96": _get_zse_96(md5_hex),
+    }

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -1,0 +1,130 @@
+"""x-zse-96 签名模块与下载器接入测试"""
+
+from unittest.mock import patch
+
+from zhihu_downloader.core.downloader import AsyncDownloader
+from zhihu_downloader.core.zhihu_signature import (
+    XZSE_93_VERSION,
+    generate_zhihu_sign,
+)
+
+D_C0 = "ABCDEFabcdef0123456789abcdef0123456789abcdef0123456789"
+ZHIHU_URL = "https://www.zhihu.com/api/v4/articles/123?include=data%5B*%5D"
+
+
+class TestGenerateZhihuSign:
+    """签名生成函数测试"""
+
+    def test_no_d_c0_returns_empty(self) -> None:
+        """无 d_c0 时返回空字典"""
+        assert generate_zhihu_sign(ZHIHU_URL, {}) == {}
+        assert generate_zhihu_sign(ZHIHU_URL, {"z_c0": "xyz"}) == {}
+        assert generate_zhihu_sign(ZHIHU_URL, {"d_c0": ""}) == {}
+
+    def test_with_d_c0_returns_signed_headers(self) -> None:
+        """有 d_c0 时返回带 2.0_ 前缀且长度合理的 x-zse-96"""
+        headers = generate_zhihu_sign(ZHIHU_URL, {"d_c0": D_C0})
+        assert "x-zse-96" in headers
+        assert "x-zst-81" in headers
+        assert headers["x-zse-96"].startswith("2.0_")
+        # "2.0_" + 64 个编码字符 = 68
+        assert len(headers["x-zse-96"]) == 68
+        assert headers["x-zst-81"].startswith("3_2.0")
+
+    def test_signature_is_reproducible_when_random_patched(self) -> None:
+        """patch random.randint 后签名可复现"""
+        with patch(
+            "zhihu_downloader.core.zhihu_signature.random.randint", return_value=42
+        ):
+            first = generate_zhihu_sign(ZHIHU_URL, {"d_c0": D_C0})
+            second = generate_zhihu_sign(ZHIHU_URL, {"d_c0": D_C0})
+        assert first == second
+
+    def test_signature_depends_on_url_and_query(self) -> None:
+        """签名基于实际请求 URL（含 query string）"""
+        with patch(
+            "zhihu_downloader.core.zhihu_signature.random.randint", return_value=42
+        ):
+            base = generate_zhihu_sign(
+                "https://www.zhihu.com/api/v4/articles/123", {"d_c0": D_C0}
+            )
+            with_query = generate_zhihu_sign(
+                "https://www.zhihu.com/api/v4/articles/123?include=data",
+                {"d_c0": D_C0},
+            )
+            other = generate_zhihu_sign(
+                "https://www.zhihu.com/api/v4/articles/456", {"d_c0": D_C0}
+            )
+        assert base["x-zse-96"] != with_query["x-zse-96"]
+        assert base["x-zse-96"] != other["x-zse-96"]
+        # x-zst-81 为固定常量，不随 URL 变化
+        assert base["x-zst-81"] == with_query["x-zst-81"] == other["x-zst-81"]
+
+    def test_different_d_c0_produce_different_signature(self) -> None:
+        """不同 d_c0 产生不同签名"""
+        with patch(
+            "zhihu_downloader.core.zhihu_signature.random.randint", return_value=42
+        ):
+            a = generate_zhihu_sign(ZHIHU_URL, {"d_c0": D_C0})
+            b = generate_zhihu_sign(ZHIHU_URL, {"d_c0": D_C0 + "0"})
+        assert a["x-zse-96"] != b["x-zse-96"]
+
+
+class TestDownloaderSignatureIntegration:
+    """下载器签名头接入测试"""
+
+    def _downloader(self) -> AsyncDownloader:
+        return AsyncDownloader(cookies={"d_c0": D_C0})
+
+    def test_zhihu_url_with_d_c0_adds_signature_headers(self) -> None:
+        """知乎系请求且含 d_c0 时自动追加签名头"""
+        downloader = self._downloader()
+        headers = downloader._build_headers(None, ZHIHU_URL)
+        assert headers["x-zse-96"].startswith("2.0_")
+        assert headers["x-zst-81"].startswith("3_2.0")
+        assert headers["x-zse-93"] == XZSE_93_VERSION
+
+    def test_non_zhihu_url_has_no_signature_headers(self) -> None:
+        """非知乎系请求不追加签名头"""
+        downloader = self._downloader()
+        headers = downloader._build_headers(None, "https://example.com/api")
+        assert "x-zse-96" not in headers
+        assert "x-zst-81" not in headers
+        assert "x-zse-93" not in headers
+
+    def test_zhihu_url_without_d_c0_has_no_signature_headers(self) -> None:
+        """知乎系请求但无 d_c0 时不追加签名头"""
+        downloader = AsyncDownloader(cookies={"z_c0": "xyz"})
+        headers = downloader._build_headers(None, ZHIHU_URL)
+        assert "x-zse-96" not in headers
+        assert "x-zst-81" not in headers
+        assert "x-zse-93" not in headers
+
+    def test_custom_headers_can_override_signature(self) -> None:
+        """用户自定义 headers 可覆盖自动签名头"""
+        downloader = self._downloader()
+        headers = downloader._build_headers({"x-zse-96": "2.0_custom"}, ZHIHU_URL)
+        assert headers["x-zse-96"] == "2.0_custom"
+        # 其余签名头仍保留
+        assert headers["x-zst-81"].startswith("3_2.0")
+        assert headers["x-zse-93"] == XZSE_93_VERSION
+
+    def test_zhihu_subdomain_is_detected(self) -> None:
+        """zhihu.com 子域（api/zhuanlan）也能识别为知乎系"""
+        downloader = self._downloader()
+        for host in (
+            "https://www.zhihu.com/x",
+            "https://api.zhihu.com/x",
+            "https://zhuanlan.zhihu.com/x",
+        ):
+            assert downloader._is_zhihu_url(host), host
+        assert not downloader._is_zhihu_url("https://notzhihu.com/x")
+        assert not downloader._is_zhihu_url("https://zhihu.com.evil.com/x")
+
+    def test_signature_build_returns_empty_when_generation_fails(self) -> None:
+        """当签名生成函数返回空 dict 时不注入任何签名头"""
+        downloader = self._downloader()
+        with patch(
+            "zhihu_downloader.core.downloader.generate_zhihu_sign", return_value={}
+        ):
+            assert downloader._build_signature_headers(ZHIHU_URL) == {}


### PR DESCRIPTION
## 处理 3 个 open issue

### #4 盐选小说有 zse-ck 反爬
- 新增 `src/zhihu_downloader/core/zhihu_signature.py`：纯 Python 标准库实现 `x-zse-96` / `x-zst-81` 签名（移植自 MediaCrawler zhihu.js 的公开实现，保留许可说明）
- 接入 `AsyncDownloader.fetch`：请求知乎系域名且 cookies 含 `d_c0` 时，自动注入 `x-zse-96`、`x-zst-81`、`x-zse-93` 请求头；用户自定义 headers 可覆盖
- 新增 `tests/test_signature.py` 11 个测试；全量 **139 passed, 1 skipped**

### #3 Releases 里没有下载的内容
- 新增 `.github/workflows/release.yml`：推送 `v*` tag 自动构建并发布 CLI 产物
  - Linux x86_64（ubuntu-24.04 + PyInstaller onefile）→ `zhihu-downloader-<version>-linux-x64.tar.gz`
  - Windows x64（windows-2022 + PyInstaller onefile）→ `zhihu-downloader-<version>-windows-x64.zip`
- 旧 `build-windows.yml`（Wine 交叉编译）改为仅手动触发，避免与统一发布流水线冲突
- Tauri 桌面端仍由 `build-tauri.yml` 负责

### #2 无法下载 story.zhihu.com 上“仅 APP 内阅读”的盐选小说
- 新增 README「支持范围与限制」小节 + `docs/SUPPORT_MATRIX.md` 支持矩阵
- 明确说明“仅 APP 内阅读”（需 mst/xsec 移动端签名）暂不支持，并给出 3 条替代方案（换 web market URL / APP 缓存或截图 / 更新 Cookie 配合 x-zse-96 签名）
- 修正 `.gitignore` 误忽略 `*.md` 的问题

## 验证
- `uv run --extra dev pytest -q` → **139 passed, 1 skipped**
- release.yml YAML 语法通过；PyInstaller Linux 实构建成功（`--help` exit 0）
